### PR TITLE
Update readme.md to prep for next release

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,17 @@
 # Tiger Moth Aerobatic Smoke (MSFS)
 
-This is a mod to [Ant's Tiger Moth for MSFS](https://www.antsairplanes.com/msfstigermoth.html) to add aerobatic smoke. It is based on (and should be used with) v1.4.1
+This is a mod to [Ant's Tiger Moth for MSFS](https://www.antsairplanes.com/msfstigermoth.html) to add aerobatic smoke. It is based on (and should be used with) v1.4.1.
 
 Coloured display smoke (red/white/blue) can be set using the following controls (choose whatever key/joystick combinations as appropriate):
 
-Effect             | Control Name             | Suggested Binding
--------------------|--------------------------|-------------------------------------------
-Toggle White Smoke | Toggle Windshield Deice or Smoke Toggle (MSFS2024) | <kbd>i</kbd>
-Toggle Blue Smoke  | Toggle Engine 1 Anti Ice | <kbd><kbd>Shift</kbd> + <kbd>i</kbd></kbd>
-Toggle Red Smoke   | Toggle Plasma            | <kbd><kbd>Ctrl</kbd> + <kbd>i</kbd></kbd>
-Toggle Smoke Intensity | Toggle G Limiter | <kbd><kbd>Alt</kbd> + <kbd>i</kbd></kbd>
+Effect                                 | Control Name               | Suggested Binding
+---------------------------------------|----------------------------|-------------------------------------------
+Toggle White Smoke (MSFS 2020/2024)    | `Smoke Toggle`             | <kbd>i</kbd>
+Toggle White Smoke  (MSFS 2020 only *) | `Toggle Windshield Deice`  | <kbd>i</kbd>
+Toggle Blue Smoke                      | `Toggle Engine 1 Anti Ice` | <kbd><kbd>Shift</kbd> + <kbd>i</kbd></kbd>
+Toggle Red Smoke                       | `Toggle Plasma`            | <kbd><kbd>Ctrl</kbd> + <kbd>i</kbd></kbd>
+Toggle Smoke Intensity                 | `Toggle G Limiter`         | <kbd><kbd>Alt</kbd> + <kbd>i</kbd></kbd>
+
+(*) White smoke used to be controlled by `Toggle Windshield Deice`, but this didn't work in MSFS 2024 so has been changed to `Smoke Toggle`. For compatibility, `Toggle Windshield Deice` will continue to work in MSFS 2020 for the time being, but as of v1.1.0, this should be considered deprecated and may be removed in a future version. Please update your mappings to use `Smoke Toggle` instead.
+
+The smoke has two intensity levels. The default is "more intense". It can be switched to "less intense" with the `Toggle G Limiter`


### PR DESCRIPTION
Mostly reformatting, but also declared the old 2020 mapping `Toggle Widshield Deice` as deprecated. There's no rush to remove it, both will work, but if/when there's a major version 2.y.z, then that might be an opportunity to tidy up. Might as well get people to transition to the new control.